### PR TITLE
Address HTTP/2 File Length issues

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@
 * NEW: Add filter 'document_read_uses_read' to use read_document capability (and not read) to read documents
 * NEW: Add filter 'document_serve_use_gzip' to determine if gzip should be used to serve file (subject to browser negotiation).
 * NEW: Add filter 'document_serve' to filter the file to be served (needed for encrypted at rest files)
+* NEW: New Crowdin updates (#244, #245)
 * FIX: Access to revisions when permalink structure not defined.
 * FIX: Design conflict with Elementor (#230) @NeilWJames
 * FIX: Document directory incorrect test for Absolute/Relative entry on Windows implementations
@@ -30,6 +31,7 @@
 * FIX: Review documentation. (#208) @NeilWJames
 * FIX: Review of Rewrite rules with/without trailing slash; also extend file extension length
 * FIX: Testing of blocks showed that if document taxonomies are changed, then existing blocks may not work. Some changes are now handled. (#217) @NeilWJames
+* FIX: Fixing compatibility issue with double slash in Documents URL when using WPML (#218) @BobbyKarabinakis
 * DEV: Update code to WP Coding Standards 2.2.1 (and fix new sniff errors)
 * DEV: Update coveralls to 2.2, dealerdirect/codesniffer to 0.6, phpunit/phpunit to 8.5 and wp/cli to 2.4.1
 * DEV: Rewrite Test library to increase code coverage.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### 3.3.1
+
+* FIX: Content-Length header suppressed for HTTP/2 File Serve. {#254)
+* FIX: MOD_DEFLATE modifies etag, so no caching occurred in this case.
+* FIX: Gzip process invoked for encodings gzip, x-gzip and delflate.
+
 ### 3.3.0
 
 * SECURITY: Password-protected document can leak existence (by showing next/previous)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 * FIX: Content-Length header suppressed for HTTP/2 File Serve. {#254)
 * FIX: MOD_DEFLATE modifies etag, so no caching occurred in this case.
-* FIX: Gzip process invoked for encodings gzip, x-gzip and delflate.
+* FIX: Gzip process invoked for encodings gzip, x-gzip and deflate.
 
 ### 3.3.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 4.6
 Tested up to: 5.7
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 
 == Description ==
 
@@ -175,6 +175,12 @@ In: class-wp-document-revisions.php
 
 
 == Changelog ==
+
+= 3.3.1 =
+
+* FIX: Content-Length header suppressed for HTTP/2 File Serve. {#254)
+* FIX: MOD_DEFLATE modifies etag, so caching blocked in this case.
+* FIX: Gzip process invoked for encodings gzip, x-gzip and delflate.
 
 = 3.3.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ In: class-wp-document-revisions.php
 
 * FIX: Content-Length header suppressed for HTTP/2 File Serve. (#254)
 * FIX: MOD_DEFLATE modifies etag, so no caching occurred in this case.
-* FIX: Gzip process now invoked for encodings gzip, x-gzip and delflate.
+* FIX: Gzip process invoked for encodings gzip, x-gzip and deflate.
 
 = 3.3.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,6 @@
 
 Contributors: benbalter
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
-Requires at least: 4.6
 Tested up to: 5.7
 Stable tag: 3.3.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,7 @@ In: class-wp-document-revisions.php
 * NEW: Add filter 'document_read_uses_read' to use read_document capability (and not read) to read documents
 * NEW: Add filter 'document_serve_use_gzip' to determine if gzip should be used to serve file (subject to browser negotiation).
 * NEW: Add filter 'document_serve' to filter the file to be served (needed for encrypted at rest files)
+* NEW: New Crowdin updates (#244, #245)
 * FIX: Access to revisions when permalink structure not defined.
 * FIX: Design conflict with Elementor (#230) @NeilWJames
 * FIX: Document directory incorrect test for Absolute/Relative entry on Windows implementations
@@ -206,6 +207,7 @@ In: class-wp-document-revisions.php
 * FIX: Review documentation. (#208) @NeilWJames
 * FIX: Review of Rewrite rules with/without trailing slash; also extend file extension length
 * FIX: Testing of blocks showed that if document taxonomies are changed, then existing blocks may not work. Some changes are now handled. (#217) @NeilWJames
+* FIX: Fixing compatibility issue with double slash in Documents URL when using WPML (#218) @BobbyKarabinakis
 * DEV: Update code to WP Coding Standards 2.2.1 (and fix new sniff errors)
 * DEV: Update coveralls to 2.2, dealerdirect/codesniffer to 0.6, phpunit/phpunit to 8.5 and wp/cli to 2.4.1
 * DEV: Rewrite Test library to increase code coverage.

--- a/readme.txt
+++ b/readme.txt
@@ -178,9 +178,9 @@ In: class-wp-document-revisions.php
 
 = 3.3.1 =
 
-* FIX: Content-Length header suppressed for HTTP/2 File Serve. {#254)
-* FIX: MOD_DEFLATE modifies etag, so caching blocked in this case.
-* FIX: Gzip process invoked for encodings gzip, x-gzip and delflate.
+* FIX: Content-Length header suppressed for HTTP/2 File Serve. (#254)
+* FIX: MOD_DEFLATE modifies etag, so no caching occurred in this case.
+* FIX: Gzip process now invoked for encodings gzip, x-gzip and delflate.
 
 = 3.3.0 =
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -4,6 +4,7 @@ Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
 Version: 3.3.1
+Requires at least: 4.6
 Author: Ben Balter
 Author URI: http://ben.balter.com
 License: GPL3

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 3.3.0
+Version: 3.3.1
 Author: Ben Balter
 Author URI: http://ben.balter.com
 License: GPL3


### PR DESCRIPTION
This addresses the issues identified in #254.

Realised the problem that I had yesterday and are now getting the file length correctly.

Can support deflate compression as it's simply a case of calling a different PHP function and labelling the encoding appropriately. x-gzip is simply a synonym for gzip.

Whilst I believe that I could have written the length header for HTTP/2, but since it's optional... (and I don't have an http/2 site available to me to test.)

I have restructured the processing within serve_file quite a bit, but it is really to ensure that I don't output any headers until the last possible moment. However for a 304, that's quite early.

I do hope that this resolved all the issues seen in delivering the files to users.

I have labelled this as a 3.3.1 release. 

Regards,
Neil