### PR TITLE
Document with valid attachment may not be found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
     "config": {
      "bin-dir": "bin",
      "vendor-dir": "vendor"
+     "allow-plugins": {
+       "dealerdirect/phpcodesniffer-composer-installer": true
+     }
    }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "config": {
      "bin-dir": "bin",
-     "vendor-dir": "vendor"
+     "vendor-dir": "vendor",
      "allow-plugins": {
        "dealerdirect/phpcodesniffer-composer-installer": true
      }

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     },
     "require-dev": {
       "phpunit/phpunit": "^5.7 || ^6.4 || ^7.5",
-      "wp-cli/wp-cli": "~2.4",
+      "wp-cli/wp-cli": "~2.6",
       "wp-coding-standards/wpcs": "~2.3",
       "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
       "php-coveralls/php-coveralls": "*",
-      "squizlabs/php_codesniffer": "~3.5",
+      "squizlabs/php_codesniffer": "~3.7",
       "yoast/phpunit-polyfills": "*"
     },
     "config": {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.4.1
+
+* FIX: Valid document may not be found.
+" FIX: Improve notification process when activation user does not have edit_documents capability.
+
 ### 3.4.0
 
 * SECURITY: WordPress can create images for PDF documents which if used would leak the hidden document name so image name changed.

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -74,11 +74,13 @@ Yes. Just follow the [standard WordPress SSL instructions](https://wordpress.org
 
 ### Can I tag my documents? What about categories or some other grouping?
 
-Yes. You can use the [Simple Taxonomy plugin](https://wordpress.org/plugins/simple-taxonomy/) to add taxonomies, or can share your existing taxonomies (e.g., the ones you use for posts) with documents.
+Yes. You can use the [Simple Taxonomy Refreshed plugin](https://wordpress.org/plugins/simple-taxonomy-refreshed/) to add taxonomies, or can share your existing taxonomies (e.g., the ones you use for posts) with documents.
 
 ### Can I put my documents in folders?
 
-WP Document Revisions doesn't use the traditional folder metaphor to organize files. Instead, the same document can be described multiple ways, or in folder terms, be in multiple folders at once. This gives you more control over your documents and how they are organized. You can add a folder taxonomy with the [Simple Taxonomy Refreshed](https://wordpress.org/plugins/simple-taxonomy-refreshed/). Just add the taxonomy with a post type of "Documents", and as the "Hierarchical" set to True.
+WP Document Revisions doesn't use the traditional folder metaphor to organize files. Instead, the same document can be described multiple ways, or in folder terms, be in multiple folders at once. This gives you more control over your documents and how they are organized. You can add a folder taxonomy with the [Simple Taxonomy Refreshed](https://wordpress.org/plugins/simple-taxonomy-refreshed/) plugin. Just add the taxonomy with a post type of "Documents", and as the "Hierarchical" set to True.
+
+Since a document can have many categories assigned at the same time, this is logically equivalent to being in many folders simultaneously.
 
 ### What if I want even more control over my workflow?
 

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -538,7 +538,7 @@ class WP_Document_Revisions_Admin {
 			$mod_date = $latest_version->post_modified;
 			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 			// translators: %1$s is the post modified date in words, %2$s is the post modified date in time format, %3$s is how long ago the post was modified, %4$s is the author's name.
-			printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $mod_date, strtotime( $mod_date ), human_time_diff( (int) get_post_modified_time( 'U', true, $post->ID ), time() ), get_the_author_meta( 'display_name', $latest_version->post_author ) );
+			printf( __( 'Checked in <abbr class="timestamp" title="%1$s" id="A%2$s">%3$s</abbr> ago by %4$s', 'wp-document-revisions' ), $mod_date, strtotime( $mod_date ), human_time_diff( (int) get_post_modified_time( 'U', true, $post->ID ), time() ), get_the_author_meta( 'display_name', $latest_version->post_author ) );
 			// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 			</em>
@@ -575,6 +575,7 @@ class WP_Document_Revisions_Admin {
 		$key          = $this->get_feed_key();
 		?>
 		<table id="document-revisions">
+			<thead>
 			<tr class="header">
 				<th><?php esc_html_e( 'Modified', 'wp-document-revisions' ); ?></th>
 				<th><?php esc_html_e( 'User', 'wp-document-revisions' ); ?></th>
@@ -585,6 +586,8 @@ class WP_Document_Revisions_Admin {
 					<th><?php esc_html_e( 'Actions', 'wp-document-revisions' ); ?></th>
 				<?php } ?>
 			</tr>
+			</thead>
+			<tbody>
 		<?php
 
 		$i = 0;
@@ -610,7 +613,7 @@ class WP_Document_Revisions_Admin {
 			}
 			?>
 			<tr>
-				<td><a href="<?php echo esc_url( $fn ); ?>" title="<?php echo esc_attr( $revision->post_modified ); ?>" class="timestamp" id="<?php echo esc_attr( strtotime( $revision->post_modified ) ); ?>"><?php echo esc_html( human_time_diff( strtotime( $revision->post_modified_gmt ), time() ) ); ?></a></td>
+				<td><a href="<?php echo esc_url( $fn ); ?>" title="<?php echo esc_attr( $revision->post_modified ); ?>" class="timestamp"><?php echo esc_html( human_time_diff( strtotime( $revision->post_modified_gmt ), time() ) ); ?></a></td>
 				<td><?php echo esc_html( get_the_author_meta( 'display_name', $revision->post_author ) ); ?></td>
 				<td><?php echo esc_html( $revision->post_excerpt ); ?></td>
 				<?php if ( $can_edit_doc && $post->ID !== $revision->ID && $i > 2 ) { ?>
@@ -635,6 +638,7 @@ class WP_Document_Revisions_Admin {
 			<?php
 		}
 		?>
+		</tbody>
 		</table>
 		<p style="padding-top: 10px;"><a href="<?php echo esc_url( add_query_arg( 'key', $key, get_post_comments_feed_link( $post->ID ) ) ); ?>"><?php esc_html_e( 'RSS Feed', 'wp-document-revisions' ); ?></a></p>
 		<?php
@@ -717,6 +721,14 @@ class WP_Document_Revisions_Admin {
 
 		// don't fire more than once.
 		if ( ! get_settings_errors( 'document_upload_directory' ) ) {
+			if ( ! is_multisite() ) {
+				// does directory exist.
+				if ( ! is_dir( $dir ) ) {
+					add_settings_error( 'document_upload_directory', 'document-upload-dir-exists', __( 'Document directory does not appear to exist. Please review value.', 'wp-document-revisions' ), 'updated' );
+				} elseif ( ! is_writable( $dir ) ) {
+					add_settings_error( 'document_upload_directory', 'document-upload-dir-write', __( 'Document directory is not writable. Please check permissions.', 'wp-document-revisions' ), 'updated' );
+				}
+			}
 			// dir changed, throw warning.
 			add_settings_error( 'document_upload_directory', 'document-upload-dir-change', __( 'Document upload directory changed, but existing uploads may need to be moved to the new folder to ensure they remain accessible.', 'wp-document-revisions' ), 'updated' );
 		}

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -92,7 +92,7 @@
  * Type     Error
  * Message  Document attachment exists but related file not in document location
  * Fixable  Yes
- * Cause    Post_content contain an h post belonging the document, but the attached file is in the media library, not the document one.
+ * Cause    Post_content contain an attachment post belonging the document, but the attached file is in the media library, not the document one.
  *          Hence moving the file will make it available.
  *
  * Code     8
@@ -100,7 +100,7 @@
  * Message  Document attachment file exists but is not readable
  * Fixable  Yes
  * Cause    Post_content contain an attachment post belonging the document, and the attached file exists but is not readable.
- *          Changing the permissions to the file will make it available. But this needs to be done at the OS level. 
+ *          Changing the permissions to the file will make it available. But this needs to be done at the OS level.
  */
 
 /**

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -18,7 +18,7 @@
  * Each new version of the document will be uploaded as an attachment to the original document post.
  * Therefore all attachments and document revisions will have their post_parent set to the original document post.
  * [Note. If a featured image is loaded then it would also have its attachment post with post_parent. This is explicitly set to 0 on loading.]
- * The attachment record contains the link to acutal data file.
+ * The attachment record contains the link to actual data file.
  * The actual attachment to use is held in the post_content field.
  * Whilst it is normal that the latest loaded attachment, this is not necessarily so if a revision is reverted.
  * However the latest one will be used if the correct one cannot be found.
@@ -32,6 +32,7 @@
  * It will then try to validate that attachment record.
  * This should be an MD5-format name (32 hexaecimal name). If not it will change the name.
  * The file that it points to should exist there.
+ * That file should be readable.
  * [If the document directory is different to the media directory, it will also check that it is in the media one, and if found propose to move it.]
  *
  * This code uses direct SQL calls to identify the document posts and to choose a potential attachment. .
@@ -84,15 +85,22 @@
  * Type     Warning
  * Message  Document attachment does not appear to be md5 encoded
  * Fixable  Yes
- * Cause    Post_content contain an attaclment post belonging the document, but the attached file does not appear to have an MD5-coded name.
+ * Cause    Post_content contain an attachment post belonging the document, but the attached file does not appear to have an MD5-coded name.
  *          Can rename it to ensure that it is.
  *
  * Code     7
  * Type     Error
  * Message  Document attachment exists but related file not in document location
  * Fixable  Yes
- * Cause    Post_content contain an attaclment post belonging the document, but the attached file is in the media library, not the document one.
+ * Cause    Post_content contain an h post belonging the document, but the attached file is in the media library, not the document one.
  *          Hence moving the file will make it available.
+ *
+ * Code     8
+ * Type     Error
+ * Message  Document attachment file exists but is not readable
+ * Fixable  Yes
+ * Cause    Post_content contain an attachment post belonging the document, and the attached file exists but is not readable.
+ *          Changing the permissions to the file will make it available. But this needs to be done at the OS level. 
  */
 
 /**
@@ -623,6 +631,16 @@ class WP_Document_Revisions_Validate_Structure {
 				'code'  => 3,
 				'error' => 1,
 				'msg'   => __( 'Document attachment exists but related file not found', 'wp-document-revisions' ),
+				'fix'   => 0,
+			);
+		}
+
+		if ( ! is_readable( $file ) ) {
+			// file is not readablet.
+			return array(
+				'code'  => 8,
+				'error' => 1,
+				'msg'   => __( 'Document attachment file exists but is not readable', 'wp-document-revisions' ),
 				'fix'   => 0,
 			);
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 
 Contributors: benbalter, nwjames
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
-Tested up to: 5.8
-Stable tag: 3.4.0
+Tested up to: 6.0.1
+Stable tag: 3.4.1
 
 == Description ==
 
@@ -178,6 +178,11 @@ In: class-wp-document-revisions.php
 
 
 == Changelog ==
+
+= 3.4.1 =
+
+* FIX: Valid document may not be found.
+" FIX: Improve notification process when activation user does not have edit_documents capability.
 
 = 3.4.0 =
 
@@ -1098,7 +1103,7 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 = Permissions management =
 
-* [Members � Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
+* [Members   Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
 
 	(Previously called Members)
 

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -3,7 +3,7 @@
 Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
-Version: 3.4.0
+Version: 3.4.1
 Requires at least: 4.6
 Author: Ben Balter
 Author URI: http://ben.balter.com


### PR DESCRIPTION
Support forum user identified a valid document may give a Not Found error. 
Whilst I don't understand why it worked for me, it was clearly a bug.
I believe that other users can also be experiencing this issue, so I have (hopefully) prepared for a 3.4.1 release.

There was also a user with permissions issue not showing a complete menu. 
Whilst there was code to alert the user, in a multi-user environment, this may not have been seen, so I have modified the notification processing somewhat to ensure that the message is displayed.