### PR TITLE
Use local post date

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -790,7 +790,7 @@ class WP_Document_Revisions {
 		} else {
 			// build documents/yyyy/mm/slug.
 			$extension = $this->get_file_type( $document );
-			$timestamp = strtotime( $document->post_date_gmt );
+			$timestamp = strtotime( $document->post_date );
 
 			$link  = untrailingslashit( home_url() ) . '/' . $this->document_slug() . '/' . gmdate( 'Y', $timestamp ) . '/' . gmdate( 'm', $timestamp ) . '/';
 			$link .= ( $leavename ) ? '%document%' : $document->post_name;


### PR DESCRIPTION
#### Changes proposed

- Use the local-timezone post date rather than the GMT post date in permalinks.

#### What this fixes

When a WordPress site uses a time zone other than UTC, and a new document is published on the last day of the month at a time when UTC falls in the next month, the plugin generates an invalid permalink with the UTC month rather than the month in the local timezone. This causes a 404 error for the document's permalink.

#### How to reproduce the bug

- Set your system time to October 31, 2022 at 9 p.m.
- In Settings > General, set your WordPress time zone to Chicago.
- Add a new document, complete with upload, and publish it publicly.
- Try to view the document.
- See that a 404 error is returned, because the permalink contains `2022/11` instead of `2022/10`.

#### How to test the fix

- Flush rewrite rules.
- Follow the "reproduce the bug" steps, but see that in the end the document is viewable rather than erroring out.