### PR TITLE
Address issue to release Version 3.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * NEW: Optionally stop direct web access to document files to force access only via WordPress. (#317)
 * NEW: If a role already has "read_documents" capability, do not touch capabilities on plugin reactivation. (#315)
 * NEW: Filter 'document_home_url' to allow changes to be made to it (used with WPML). (#329)
+* FIX: Use with plugin EditFlow gives PHP 8.0 error. (#331)
 * FIX: Typo in description of default upload location. (#328)	
 * FIX: Filter 'document_revisions_owner' withdrawn as parameter acted on (who) deprecated in WP 5.9. (#316)
 * FIX: Updates to document description do not enable the Submit button

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * NEW: Filter 'document_validate_md5' to switch off attachment MD5 format validation. (#318)
 * NEW: Optionally stop direct web access to document files to force access only via WordPress. (#317)
 * NEW: If a role already has "read_documents" capability, do not touch capabilities on plugin reactivation. (#315)
+* NEW: Filter 'document_home_url' to allow changes to be made to it (used with WPML). (#329)
+* FIX: Typo in description of default upload location. (#328)	
 * FIX: Filter 'document_revisions_owner' withdrawn as parameter acted on (who) deprecated in WP 5.9. (#316)
 * FIX: Updates to document description do not enable the Submit button
 * DEV: JS scripts will be called with Defer in WP 6.3 onwards. (#314)

--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -1,0 +1,80 @@
+# WP-Documents-Revisions Data Design and Data Structure
+
+## Requirements
+
+- To maintain a reference to a document and to hold a list of published versions of the documents.
+	- It is not particularly concerned about how the document is created and the process to arrive at the state ready to upload.
+	- It will maintain a status of where it is in the publishing process.
+
+- It makes use of a custom post type "document" and revisions to maintain the history of Document file uploads.
+
+- The Document file will be uploaded using the standard Media loader.
+	- This will result in an Attachment post being created with the Document post as its parent.
+	- It will not be visible in the Media library as Queries to the Media library remove attachments with parents that are documents.
+	- Document files can be stored in a different host library.
+
+- The Document file should not be accessible directly by the user, but ideally via the WP interface.
+	- This will be supported by changing the uploaded file name to be an MD5-hash of the original file name and load time.
+	- This can be supplemented by changing .htaccess rules to stop direct access to files with MD5 format names
+	- Standard WP processing may create a JPEG image of PDF uploads.
+	- Since it will store these using the MD5 file name that will be downloaded to the user this would expose the MD5 file name. Therefore there is a process to change these images to use another name.
+
+- The document post record can also support Featured Images.
+	- If loaded via the Edit document page, it would be considered as a Document file. So the parent post identifier will be removed to eliminate confusion between it being a Featured Image and a Document file being stored.
+
+- Since version 3.4 of the plugin, it is possible to enter a user-oriented description that can be displayed to users with the shortcodes or blocks provided with the plugin.  
+
+- An audit trail of changes to published versions of the Document file.
+	- The user can enter a reason for changing the Document including uploading a Document file; changing the Document Description; or Title; or any Taxonomy element.
+	- This reason will be stored in the Excerpt field.
+	- The aggregate information may be displayed as a Revision Log.
+   
+- Use will be made of the standard WP Revisions functionality to contain the Audit Trail itself.
+	- Standard WP processing creates a Revision if any one of these fields are changed: title, content or excerpt.
+	- Since all Attachments are linked to the parent Document record, by storing the Attachment Id in the content field, then a Revision record will be created automatically. 
+
+- This plugin is delivered with just one Taxonomy - Workflow_State. This shows the status of the Document file in its processing.
+	- This is not considered very useful for user data classification.
+	- However, being a generic tool, sites can use of a dedicated Taxonomy plugin.
+
+## Data Structure
+
+The records held in the database will be:
+
+1. Document Record
+
+- post_content contains the id of the latest Document file attachment.
+	- When a Document file is loaded on editing this Document record, the post_content will be modified to contain the ID of the Attachment record created.
+	- In plugin versions prior to 3.4, this would simply be the numeric ID.
+	- Subsequent versions hold this in the form of an HTML comment "<!-- WPDR nnn -->" where nnn is the ID of the attachment. It can also contain a text Document description.
+	- When editing the post, this field is decomposed into its two parts of ID and description with program management of the former and user management of the latter, recombined automatically when changes are made.
+
+- post_excerpt will contain any comment entered when the document record is updated.
+
+- As taxonomy records are held only against this Document record, there is no effective audit trail of changes to Taxonomy. Changes can be noted manually in the excerpt field
+
+2. Attachment Record(s)
+
+There can be multiple Attachment records, one for each Document file loaded.
+
+- The name and title of the Attachment record is set to a MD5 hash of the original file name and the load time.
+
+- The Document file name is also set as this MD5 hash.
+
+- post_parent is set to the Document Record ID.
+
+- When a PDF Document file is loaded, then standard WP processing will attempt to make a JPEG image of the first page as a thumbnail (using all sizes). These will be held in the same directory as the Document file.
+	- However if the file name is MD5Hash.pdf, then these images will be called MD5Hash-pdf.jpg.
+	- If used, this would expose the name of the file to the user.
+	- To avoid this, there is a process to transform this name to another (essentially random) MD5 and rename these files.
+	- Once done, a postmeta record is created with these new file names (and another postmeta record denoting this process has been done).
+
+- If a Featured Image is loaded whilst editing the Document record, this would also have the same post_parent set, so in this case, the post_parent is set to 0.
+
+3. Revision Record(s)
+
+When saving a Document Record, standard WP processing will be invoked to detect a change in title, content or excerpt fields. If one is found then a Revision record is created.
+
+There can be multiple Revision records held, one for each saving event where a change in these fields are detected.
+
+Because the content contains the Attachment ID, an upload of a new Document file will create a new Revision.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -48,6 +48,12 @@ In: class-wp-document-revisions-admin.php
 
 Filters the default help text for current screen.
 
+## Filter document_home_url
+
+In: class-wp-document-revisions.php
+
+Filters the home_url() for WPML and translated documents.
+
 ## Filter document_internal_filename
 
 In: class-wp-document-revisions.php

--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -663,7 +663,7 @@ class WP_Document_Revisions_Admin {
 
 
 	/**
-	 * Only load documenrs from Computer.
+	 * Only load documents from Computer.
 	 *
 	 * @since 3.3
 	 *
@@ -943,7 +943,7 @@ class WP_Document_Revisions_Admin {
 		<span class="description">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.UnsafePrintingFunction
-		_e( 'Directory in which to store uploaded documents. The default is in your <code>wp_content/uploads</code> folder (or another default uploads folder defined elsewhere), but it may be moved to a folder outside of the <code>htdocs</code> or <code>public_html</code> folder for added security.', 'wp-document-revisions' );
+		_e( 'Directory in which to store uploaded documents. The default is in your <code>wp-content/uploads</code> folder (or another default uploads folder defined elsewhere), but it may be moved to a folder outside of the <code>htdocs</code> or <code>public_html</code> folder for added security.', 'wp-document-revisions' );
 		?>
 		</span>
 		<?php if ( is_multisite() ) : ?>

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -810,10 +810,14 @@ class WP_Document_Revisions_Front_End {
 				// Look up taxonomy.
 				if ( 'workflow_state' === $taxonomy && ! empty( $tax_key ) && 'workflow_state' !== $tax_key ) {
 					// EF/PP - Mis-use of 'post_status' taxonomy.
-					$tax               = get_taxonomy( $tax_key );
-					$tax->hierarchical = false;
-					$tax->label        = 'Post Status';
-					$wf_efpp           = 1;
+					$tax_arr                 = (array) get_taxonomy( $tax_key );
+					$tax_arr['hierarchical'] = false;
+					$tax_arr['label']        = 'Post Status';
+					$object_type             = $tax_arr['object_type'];
+					unset( $tax_arr['name'] );
+					unset( $tax_arr['object_type'] );
+					$tax     = new WP_Taxonomy( $tax_key, $object_type, $tax_arr );
+					$wf_efpp = 1;
 				} else {
 					$tax = get_taxonomy( $taxonomy );
 				}

--- a/includes/class-wp-document-revisions-front-end.php
+++ b/includes/class-wp-document-revisions-front-end.php
@@ -406,7 +406,7 @@ class WP_Document_Revisions_Front_End {
 			<li class="document document-<?php echo esc_attr( $document->ID ); ?>">
 			<a href="<?php echo esc_url( get_permalink( $document->ID ) ); ?>"
 				<?php echo ( $atts_new_tab ? ' target="_blank"' : '' ); ?>>
-				<?php echo esc_html( get_the_title( $document->ID ) ); ?>
+				<?php echo esc_html( get_the_title( $document->ID ) ) . wp_kses_post( $show_pdf ); ?>
 			</a>
 			<?php
 			if ( $show_edit && current_user_can( 'edit_document', $document->ID ) ) {

--- a/includes/class-wp-document-revisions-validate-structure.php
+++ b/includes/class-wp-document-revisions-validate-structure.php
@@ -261,7 +261,7 @@ class WP_Document_Revisions_Validate_Structure {
 				$content = $wpdr->format_doc_id( $parm );
 			} else {
 				// find if there is a document id there.
-				preg_match( '/(<!-- WPDR [0-9]+ -->)/', $content, $id );
+				preg_match( '/(<!-- WPDR \s*\d+ -->)/', $content, $id );
 				if ( isset( $id[1] ) ) {
 					// if a match return the id.
 					$content = str_replace( $id[1], '', $content );

--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -2009,6 +2009,7 @@ class WP_Document_Revisions {
 						if ( $use_wp_filesystem ) {
 							$wp_filesystem->move( $file_dir . $sizeinfo['file'], $file_dir . $new_file );
 							$wp_filesystem->chmod( $file_dir . $new_file, 0664 );
+							$metadata['sizes'][ $size ]['file'] = $new_file;
 						} else {
 							$dummy = null;
 							// Use copy and unlink because rename breaks streams.
@@ -2024,7 +2025,7 @@ class WP_Document_Revisions {
 				}
 			}
 		}
-		// add indicator to note it has been changeed *o no need).
+		// add indicator to note it has been changeed (so no need to reprocess).
 		add_post_meta( $attachment_id, '_wpdr_meta_hidden', true, true );
 
 		// have finished loading the attachment into the upload directory, so remove it.
@@ -2109,6 +2110,7 @@ class WP_Document_Revisions {
 					if ( $use_wp_filesystem ) {
 						$wp_filesystem->move( $file_dir . $sizeinfo['file'], $file_dir . $new_file );
 						$wp_filesystem->chmod( $file_dir . $new_file, 0664 );
+						$meta_sizes[ $size ]['file'] = $new_file;
 					} else {
 						$dummy = null;
 						// Use copy and unlink because rename breaks streams.

--- a/readme.txt
+++ b/readme.txt
@@ -605,6 +605,12 @@ In: class-wp-document-revisions-admin.php
 
 Filters the default help text for current screen.
 
+== Filter document_home_url ==
+
+In: class-wp-document-revisions.php
+
+Filters the home_url() for WPML and translated documents.
+
 == Filter document_internal_filename ==
 
 In: class-wp-document-revisions.php
@@ -1146,7 +1152,7 @@ Interested in translating WP Document Revisions? You can do so [via Crowdin](htt
 
 = Permissions management =
 
-* [Members � Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
+* [Members   Membership & User Role Editor Plugin](https://wordpress.org/plugins/members/)
 
 	(Previously called Members)
 

--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,7 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * NEW: Optionally stop direct web access to document files to force access only via WordPress. (#317)
 * NEW: If a role already has "read_documents" capability, do not touch capabilities on plugin reactivation. (#315)
 * NEW: Filter 'document_home_url' to allow changes to be made to it (used with WPML). (#329)
+* FIX: Use with plugin EditFlow gives PHP 8.0 error. (#331)
 * FIX: Typo in description of default upload location. (#328)	
 * FIX: Filter 'document_revisions_owner' withdrawn as parameter acted on (who) deprecated in WP 5.9. (#316)
 * FIX: Updates to document description do not enable the Submit button

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,8 @@ Numbers in brackets show the issue number in https://github.com/wp-document-revi
 * NEW: Filter 'document_validate_md5' to switch off attachment MD5 format validation. (#318)
 * NEW: Optionally stop direct web access to document files to force access only via WordPress. (#317)
 * NEW: If a role already has "read_documents" capability, do not touch capabilities on plugin reactivation. (#315)
+* NEW: Filter 'document_home_url' to allow changes to be made to it (used with WPML). (#329)
+* FIX: Typo in description of default upload location. (#328)	
 * FIX: Filter 'document_revisions_owner' withdrawn as parameter acted on (who) deprecated in WP 5.9. (#316)
 * FIX: Updates to document description do not enable the Submit button
 * DEV: JS scripts will be called with Defer in WP 6.3 onwards. (#314)

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: benbalter, nwjames
 Tags: documents, uploads, attachments, document management, enterprise, version control, revisions, collaboration, journalism, government, files, revision log, document management, intranet, digital asset management
 Requires at least: 4.6
-Tested up to: 6.3.1
+Tested up to: 6.4.1
 Stable tag: 3.6.0
 
 == Description ==

--- a/wp-document-revisions.php
+++ b/wp-document-revisions.php
@@ -4,7 +4,7 @@ Plugin Name: WP Document Revisions
 Plugin URI: http://ben.balter.com/2011/08/29/wp-document-revisions-document-management-version-control-wordpress/
 Description: A document management and version control plugin for WordPress that allows teams of any size to collaboratively edit files and manage their workflow.
 Version: 3.6.0
-Requires at least: 4.6
+Requires at least: 4.9
 Author: Ben Balter
 Author URI: http://ben.balter.com
 License: GPL3


### PR DESCRIPTION
@benbalter 
Sorry it has taken a time to revert with the fix to the problem I had raised with you to release V3.6.

I had hoped to address the issues for WPML.

Whilst I think think that I have them sorted (mentally at least), I think the most appropriate way to deal with it is to a plugin to go in the Cookbook that will be the functions to interface WPML, and to add filters and/or actions (if necessary) to the plugin.

I have changed the way the PDF image denotes that it has hidden itself to be better aligned with WPML processing. It will be marginally more efficient in processing than having a separate piece of metadata.

I have also fixed the issue raised today on Github which is a text typo.

Separately I wrote a document giving information on the data structures used. This was if I needed to go the the WPML folks to define how the plugin works. It certainly can be better written, but I thought it is better to be out there rather than simply on my PC.
