### PR TITLE
Update class-wp-document-revisions.php - property subdir is required.

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -1801,6 +1801,7 @@ class WP_Document_Revisions {
 			'path'    => $doc_dir . '/' . $dir['subdir'],
 			'url'     => home_url( '/' . $this->document_slug() ) . $dir['subdir'],
 			'basedir' => $doc_dir,
+			'subdir'  => '',
 			'baseurl' => home_url( '/' . $this->document_slug() ),
 			'error'   => false,
 		);


### PR DESCRIPTION
Property subdir is required, so don't remove it during the filter, just set it to an empty string. 

https://developer.wordpress.org/reference/functions/wp_upload_dir/