### PR TITLE
Fix: TypeError: window.WPDocumentRevisions is undefined

### DIFF
--- a/includes/class-wp-document-revisions-admin.php
+++ b/includes/class-wp-document-revisions-admin.php
@@ -989,7 +989,13 @@ class WP_Document_Revisions_Admin {
 		if ( 'media-upload.php' === $pagenow ) {
 			?>
 			<script type="text/javascript">
-				document.addEventListener('DOMContentLoaded', function() {window.WPDocumentRevisions.bindPostDocumentUploadCB()});
+				document.addEventListener('DOMContentLoaded', function() {
+					if(window.WPDocumentRevisions) {
+						window.WPDocumentRevisions.bindPostDocumentUploadCB();
+					} else {
+						jQuery(function() {window.WPDocumentRevisions.bindPostDocumentUploadCB()});
+					}
+				});
 			</script>
 			<?php
 		}


### PR DESCRIPTION
This PR fixes an error that I've seen where the following error is returned.

```
TypeError: Cannot read properties of undefined (reading 'bindPostDocumentUploadCB')
    at HTMLDocument.<anonymous> (VM5802 media-upload.php:3:33)
```

To reproduce the error. 

- Open console in browser
- Create a new document
- Click Upload new version.
- You will see the error is logged.