### PR TITLE
Translations should only be called on/after init

### DIFF
--- a/includes/class-wp-document-revisions-recently-revised-widget.php
+++ b/includes/class-wp-document-revisions-recently-revised-widget.php
@@ -34,10 +34,9 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 * Init widget and register.
 	 */
 	public function __construct() {
-		parent::__construct( 'WP_Document_Revisions_Recently_Revised_Widget', __( 'Recently Revised Documents', 'wp-document-revisions' ) );
-
-		// can't i18n outside of a function.
-		$this->defaults['title'] = __( 'Recently Revised Documents', 'wp-document-revisions' );
+		// Do translation stuff in widgets_init.
+		parent::__construct( 'WP_Document_Revisions_Recently_Revised_Widget', 'Recently Revised Documents' );
+		null;
 	}
 
 
@@ -438,6 +437,11 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 	 * Callback to register the recently revised widget.
 	 */
 	public function wpdr_widgets_init() {
+		$this->name = __( 'Recently Revised Documents', 'wp-document-revisions' );
+
+		// can't i18n outside of a function.
+		$this->defaults['title'] = __( 'Recently Revised Documents', 'wp-document-revisions' );
+
 		global $wpdr_widget;
 
 		register_widget( $wpdr_widget );


### PR DESCRIPTION
Changes have already been made to ensure translations are only done on/after the init hook.

WP 6.8 includes a doing_it_wrong call for translations - showing that the widget __construct call was being done during plugin_loaded, i.e. earlier that included translations.

This fix ensures that translation calls are not done prior to the init hook.