### PR TITLE
Update sanitize function for slug in `update_post_slug_field`

### DIFF
--- a/includes/class-wp-document-revisions.php
+++ b/includes/class-wp-document-revisions.php
@@ -3335,7 +3335,7 @@ class WP_Document_Revisions {
 		check_ajax_referer( 'samplepermalink', 'samplepermalinknonce' );
 		$post_id = isset( $_POST['post_id'] ) ? (int) sanitize_text_field( wp_unslash( $_POST['post_id'] ) ) : 0;
 		$title   = isset( $_POST['new_title'] ) ? sanitize_text_field( wp_unslash( $_POST['new_title'] ) ) : '';
-		$slug    = isset( $_POST['new_slug'] ) ? sanitize_text_field( wp_unslash( $_POST['new_slug'] ) ) : null;
+		$slug    = isset( $_POST['new_slug'] ) ? sanitize_title( wp_unslash( $_POST['new_slug'] ) ) : null;
 
 		if ( ! $this->verify_post_type( $post_id ) ) {
 			// not a document so do nothing. If another function linked, then exit otherwise do as sample.


### PR DESCRIPTION
Previous to this change, a document slug could be set with non-allowed characters, e.g. whitespace.