### PR TITLE
Add explicit null return to widget form() for wordpress-stubs 7.x

### DIFF
--- a/includes/class-wp-document-revisions-recently-revised-widget.php
+++ b/includes/class-wp-document-revisions-recently-revised-widget.php
@@ -233,6 +233,7 @@ class WP_Document_Revisions_Recently_Revised_Widget extends WP_Widget {
 			<input type="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'new_tab' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'new_tab' ) ); ?>" <?php checked( $instance['new_tab'] ); ?> /> <?php esc_html_e( 'Yes', 'wp-document-revisions' ); ?>
 		</p>
 		<?php
+		return null;
 	}
 
 


### PR DESCRIPTION
## What

Adds an explicit `return null;` to `WP_Document_Revisions_Recently_Revised_Widget::form()`.

## Why

Dependabot #673 bumps `szepeviktor/phpstan-wordpress` 2.0.3 → 2.0.4, which pulls `php-stubs/wordpress-stubs` v6.9.4 → **v7.1.0**. The WP 7 stubs redeclare `WP_Widget::form()` with a `string|null` return type, so PHPStan flags our override for having no return statement:

```
Method WP_Document_Revisions_Recently_Revised_Widget::form() should return string|null but return statement is missing.
```

The form is echoed rather than returned, so returning `null` explicitly is correct (the parent's default returns the `'noform'` sentinel; a rendered form returns null). This unblocks the phpstan-wordpress 2.0.4 bump in #673.

## Testing

Ran PHPStan against the exact dependency set from #673 (phpstan-wordpress 2.0.4 / wordpress-stubs 7.1.0) → **No errors**. Also confirmed it still passes on current `main`'s deps (2.0.3 / 6.9.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)