### PR TITLE
Declare react and react-dom as explicit devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@wordpress/scripts": "^34.0.0",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "~29.7.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "terser": "^5.50.0",
         "typescript": "^5.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@wordpress/scripts": "^34.0.0",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "~29.7.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
## What

Adds `react` and `react-dom` (`^18.3.1`) as explicit devDependencies.

## Why

`@testing-library/react`'s `act-compat` shim requires `react-dom/test-utils` to be resolvable. `react-dom` was only present in the tree transitively, via `@wordpress/element`, which used to declare it as a direct dependency.

The `@wordpress/scripts` 34.1.0 bump (#663) pulls a newer `@wordpress/element` that moves `react`/`react-dom` to **peer** dependencies. Since nothing in `package.json` declared `react-dom` directly, npm prunes it from the regenerated lockfile, and the JS test suite fails at import time:

```
Cannot find module 'react-dom/test-utils' from 'node_modules/@testing-library/react/dist/act-compat.js'
```

Declaring `react` and `react-dom` as direct devDependencies keeps them in the lockfile regardless of transitive resolution. Pinned to `^18.3.1` to match the currently-resolved versions (and keep `react`/`react-dom` in lockstep).

These are build/test-only: WordPress provides React at runtime and `@wordpress/scripts` externalizes it, so the shipped bundle is unaffected.

## Testing

Reproduced the failure with `npm ci` against #663's lockfile (react-dom absent → suite fails). With this change, `npm ci` restores `react-dom@18.3.1` and the full suite passes: **9 suites / 367 tests**. On current `main` the lockfile diff is limited to the two new dependency entries (react/react-dom were already resolved at 18.3.1). Verified in a node:22 container to match CI. This unblocks #663 once rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)